### PR TITLE
#30 [Fix] 테스트 커버리지 측정 시 예외 패턴 적용 및 SonarCloud 관련 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,18 +54,32 @@ jacoco {
 	toolVersion = "0.8.11"
 }
 
-// 측정 안하고 싶은 패턴
+// JaCoCo 테스트 커버리지 측정 안하고 싶은 패턴
 def jacocoExcludePatterns = [
-		"**/*Application*",
+		'*.*Application*',
+		"*.*Config*",
+		"*.*Exception*",
+		"*.test.*",
+		"*.resources.*",
+		"*.dto.*",
+		"*.entity.*",
+		"*.*Entity*",
+		"*.annotation.*",
+		"*.constant.*"
+]
+
+// JaCoCo 보고서 + SonarCloud 관련 제외 패턴
+def sonarCloudExcludePatterns = [
+		'**/*Application*',
 		"**/*Config*",
 		"**/*Exception*",
-		"**/test/**",
-		"**/resources/**",
-		"**/dto/**",
-		"**/entity/**",
+		"**/test/**/*",
+		"**/resources/**/*",
+		"**/dto/**/*",
+		"**/entity/**/*",
 		"**/*Entity*",
-		"**/annotation/**",
-		"**/constant/**"
+		"**/annotation/**/*",
+		"**/constant/**/*"
 ]
 
 //테스트 커버리지 규칙 정의하고 검증
@@ -111,7 +125,8 @@ jacocoTestReport {
 	afterEvaluate {
 		classDirectories.setFrom(
 				files(classDirectories.files.collect {
-					fileTree(dir: it, excludes: jacocoExcludePatterns)
+									  // JaCoCo 리포트 결과에 제외 시킬 패턴
+					fileTree(dir: it, excludes: sonarCloudExcludePatterns)
 				})
 		)
 	}
@@ -139,10 +154,11 @@ sonar {
 		property 'sonar.sources', 'src'
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+		property 'sonar.test.exclusions', sonarCloudExcludePatterns.join(',')
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'
 		property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+		property 'sonar.coverage.exclusions', sonarCloudExcludePatterns.join(',')
 	}
 }
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# lombok에 의해 generated된 메서드는 테스트 검증에서 제외 (Getter, Builder 등)
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/dev/backend/wakuwaku/domain/BaseEntity.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/BaseEntity.java
@@ -1,9 +1,9 @@
 package dev.backend.wakuwaku.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -12,22 +12,13 @@ import java.time.LocalDateTime;
  * '@EntityListeners(AuditingEntityListener.class)': BaseTimeEntiy 클래스에 Auditing 기능을 포함시킵니다.
  * '@CreatedDate': Entity가 생성되어 저장될 때 시간이 자동 저장됩니다.
  * '@LastModifiedDate': 조회한 Entity의 값을 변경할 때 시간이 자동 저장됩니다.
-
  */
-
 @Getter
-@Setter
 @MappedSuperclass
 public class BaseEntity {
+    @CreatedDate
+    protected LocalDateTime createDateTime;
 
-    @Column(name = "create_date_time")
-    private LocalDateTime createDateTime;
-
-    @Column(name = "last_modified_date_time")
-    private LocalDateTime lastModifiedDateTime;
-
-    // 호출 될 때마다 현재시간으로 최신화
-    public BaseEntity(){
-        this.lastModifiedDateTime = LocalDateTime.now();
-    }
+    @LastModifiedDate
+    protected LocalDateTime lastModifiedDateTime;
 }

--- a/src/main/java/dev/backend/wakuwaku/domain/StatusEntity.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/StatusEntity.java
@@ -1,16 +1,11 @@
 package dev.backend.wakuwaku.domain;
 
 
-import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @MappedSuperclass
 public class StatusEntity extends BaseEntity{
-
-    @Column(name = "check_status")
-    private String chectStatus;
+    protected String checkStatus;
 }

--- a/src/main/java/dev/backend/wakuwaku/global/config/ApiDocumentConfig.java
+++ b/src/main/java/dev/backend/wakuwaku/global/config/ApiDocumentConfig.java
@@ -1,0 +1,14 @@
+package dev.backend.wakuwaku.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ApiDocumentConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/static/dist/**").addResourceLocations("classpath:/static/dist/");
+        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/static/dist/swagger-ui/");
+    }
+}

--- a/src/main/java/dev/backend/wakuwaku/global/config/CorsConfig.java
+++ b/src/main/java/dev/backend/wakuwaku/global/config/CorsConfig.java
@@ -1,0 +1,15 @@
+package dev.backend.wakuwaku.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("*");
+    }
+}

--- a/src/main/java/dev/backend/wakuwaku/global/infra/google/places/constant/GooglePlacesAPIRequestConstant.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/google/places/constant/GooglePlacesAPIRequestConstant.java
@@ -1,0 +1,6 @@
+package dev.backend.wakuwaku.global.infra.google.places.constant;
+
+public class GooglePlacesAPIRequestConstant {
+    public static final String REQUEST_API_KEY_HEADER = "X-Goog-Api-Key";
+    public static final String TEXT_SEARCH_RESPONSE_FIELDS_HEADER = "X-Goog-FieldMask";
+}

--- a/src/main/java/dev/backend/wakuwaku/global/infra/google/places/dto/request/TextSearchRequest.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/google/places/dto/request/TextSearchRequest.java
@@ -1,0 +1,14 @@
+package dev.backend.wakuwaku.global.infra.google.places.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class TextSearchRequest {
+    public final String textQuery;
+
+    public static final String TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText";
+
+    public static final String TEXT_SEARCH_RESPONSE_FIELDS = "places.displayName,places.location,places.rating,places.id";
+}

--- a/src/test/java/dev/backend/wakuwaku/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/member/repository/MemberRepositoryTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-public class MemberRepositoryTest {
+class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,9 +1,14 @@
+# Test profile
 spring:
-  # 테스트 코드 실행하기 위해 h2 DB 사용
+  profiles:
+    active: API-KEY
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driverClassName: org.h2.Driver
+
   jpa:
-    database: h2
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        format_sql: true
-        hbm2ddl.auto: update
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+      format_sql: true


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [x] 기능 추가
- [x] 리팩토링


## Issue 번호
Issue Number: #30

## 작업 내용(기대 효과)
1. BaseEntity, StatusEntity
  - 필드들의 접근제어자를 public -> protected로 변경
  - @Setter 어노테이션 삭제
  - 호출할 때마다 현재 시간으로 최신화 해주는 생성자 삭제
  - @CreatedDate @LastModifiedDate 어노테이션 추가
  - @Colum 어노테이션 삭제
2. CorsConfig - localhost:3000가 서버의 모든 API를 정상적으로 호출이 가능하도록 설정
3. ApiDocumentConfig - API Docs에 대한 HTML 파일의 저장 경로와 저장 이름에 대한 설정
4. lombok.config - lombok으로 인해 생성되는 Getter 메서드 같은 메서드들을 테스트 측정에서 제외하기 위한 설정 파일
5. build.gradle - JaCoCo 테스트 커버리지 측정 예외 패턴 적용 및 SonarCloud 관련 설정

## 기타 사항
