### PR TITLE
[#51] Feat: 커스텀 Exception 정의 및 Exception 처리 로직 구현, BaseResponse 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,8 @@ def jacocoExcludePatterns = [
 		"*.annotation.*",
 		"*.constant.*",
 		"*.newest.*",
-		"*.Result*"
+		"*.Result*",
+		"*.BaseResponse*"
 ]
 
 // JaCoCo 보고서 + SonarCloud 관련 제외 패턴
@@ -84,7 +85,8 @@ def sonarCloudExcludePatterns = [
 		"**/annotation/**/*",
 		"**/constant/**/*",
 		"**/newest/**/*",
-		"**/Result*"
+		"**/Result*",
+		"**/BaseResponse*"
 ]
 
 //테스트 커버리지 규칙 정의하고 검증

--- a/src/main/java/dev/backend/wakuwaku/global/exception/ExceptionStatus.java
+++ b/src/main/java/dev/backend/wakuwaku/global/exception/ExceptionStatus.java
@@ -1,0 +1,26 @@
+package dev.backend.wakuwaku.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionStatus {
+    // common exception
+    INVALID_PARAMETER(BAD_REQUEST, 2000, "잘못된 요청이 존재합니다."),
+    INVALID_URL(BAD_REQUEST, 2001, "잘못된 URL 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2002,"서버 내부 오류입니다."),
+    NOT_EXISTED_FILE(NOT_EXTENDED, 2003,"존재하지 않는 파일입니다."),
+
+    // user exception
+    DUPLICATED_EMAIL(CONFLICT, 3000, "중복된 이메일이 존재합니다."),
+    NONE_USER(NOT_FOUND, 3001, "존재하지 않는 회원입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/dev/backend/wakuwaku/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/backend/wakuwaku/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package dev.backend.wakuwaku.global.exception;
+
+import dev.backend.wakuwaku.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(WakuWakuException.class)
+    public ResponseEntity<Object> handleWakuWakuException(WakuWakuException e) {
+        ExceptionStatus status = e.getStatus();
+
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(status));
+    }
+}

--- a/src/main/java/dev/backend/wakuwaku/global/exception/WakuWakuException.java
+++ b/src/main/java/dev/backend/wakuwaku/global/exception/WakuWakuException.java
@@ -1,0 +1,18 @@
+package dev.backend.wakuwaku.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WakuWakuException extends RuntimeException {
+    private final ExceptionStatus status;
+
+    public static final WakuWakuException INVALID_PARAMETER       = new WakuWakuException(ExceptionStatus.INVALID_PARAMETER);
+    public static final WakuWakuException INVALID_URL             = new WakuWakuException(ExceptionStatus.INVALID_URL);
+    public static final WakuWakuException INTERNAL_SERVER_ERROR   = new WakuWakuException(ExceptionStatus.INTERNAL_SERVER_ERROR);
+    public static final WakuWakuException NOT_EXISTED_FILE        = new WakuWakuException(ExceptionStatus.NOT_EXISTED_FILE);
+    public static final WakuWakuException DUPLICATED_EMAIL        = new WakuWakuException(ExceptionStatus.DUPLICATED_EMAIL);
+    public static final WakuWakuException NONE_USER               = new WakuWakuException(ExceptionStatus.NONE_USER);
+
+}

--- a/src/main/java/dev/backend/wakuwaku/global/response/BaseResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/global/response/BaseResponse.java
@@ -1,0 +1,37 @@
+package dev.backend.wakuwaku.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.backend.wakuwaku.global.exception.ExceptionStatus;
+import lombok.Getter;
+
+@Getter
+public class BaseResponse<T> {
+    private final Boolean isSuccess;
+    private final int code;
+    private final String message;
+
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 성공 시 반환할 데이터가 있을 때 반환되는 Response
+    public BaseResponse(T data) {
+        this.isSuccess = true;
+        this.code = 1000;
+        this.message = "요청에 성공하였습니다.";
+        this.data = data;
+    }
+
+    // 성공 시 반환할 데이터가 없을 때 반환되는 Response
+    public BaseResponse() {
+        this.isSuccess = true;
+        this.code = 1000;
+        this.message = "요청에 성공하였습니다.";
+    }
+
+    // 실패 시 반환되는 Response
+    public BaseResponse(ExceptionStatus status) {
+        this.isSuccess = false;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #51

## 작업 내용(기대 효과)
- BaseResponse<T> 구현
  - 필드값)
    - isSuccess: 성공 여부(boolean)
    - httpStatus: 반환될 HttpStatus 상태(ex. 200, 400 등)
    - code: 상태 코드. 응답 성공은 기본적으로 1000
    - data: 응답 성공시 반환할 데이터
    - maessage: 예외 발생시 반환할 예외 메세지
  - 모든 API 응답 및 예외 발생에서 활용할 수 있음.
  - 제네릭()으로 모든 형태의 응답 데이터를 Json으로 반환할 수 있음.
  - 사용 예시)
![image](https://github.com/AK-47-GrandMother/WakuWaku-BackEnd/assets/93212863/cc1342ed-7a55-4c03-9ca4-6733dc7d7e5a)

- GlobalExceptionHandler구현
  - 런타임시 발생하는 모든 WakuWakuException 예외를 감지하고 예외 정보에 대한 응답을 반환함.
  - ExceptionStatus 에 정의한 모든 예외에 대해 동작함
- ExceptionStatus 구현 및 초기화
  - 커스텀 예외를 미리 정의할 수 있는 Enum Class 구현
  - 필드값: HttpStatus, 상태 code, message(위 설명과 동일)
  - 예외 추가 방법)
    - a. Enum 타입의 변수입력
    - b. 예외에 맞는 HttpStatus, code, Message 입력
    - c. WakuWakuException 클래스에 static 필드로 추가
  - ⚠️ 주의 사항)
    - 도메인 별로 주석과 code로 묶을 것을 권장.
    - 동일 도메인 예외는 code값 순차적으로 입력.(ex. 2000, 2001, 2002 ..)
- WakuWakuException 구현
  - RuntimeException을 상속받은 커스텀 클래스 구현
  - 필드 값:
    - Enum ExceptionStatus
    - static 필드: ExceptionStatus에 정의한 모든 enum 변수들을 static 필드로 가짐. (싱글톤 객체로 관리하기 위함.)

## 기타 사항
