### PR TITLE
[#55] Fix: 검색어가 빈 칸일 때 예외가 발생하지 않는 오류 수정

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/restaurant/service/RestaurantService.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static dev.backend.wakuwaku.domain.restaurant.service.constant.SearchWordConstant.JAPAN;
 import static dev.backend.wakuwaku.global.exception.WakuWakuException.INVALID_PARAMETER;
+import static dev.backend.wakuwaku.global.exception.WakuWakuException.INVALID_SEARCH_WORD;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,10 @@ public class RestaurantService {
     }
 
     public List<Restaurant> getSimpleRestaurants(String searchWord) {
+        if (searchWord == null || searchWord.isEmpty() || searchWord.matches("^[ \t]*$")) {
+            throw INVALID_SEARCH_WORD;
+        }
+
         String newWord = duplicateWord(searchWord);
 
         List<Result> results = googlePlacesTextSearchService.textSearch(JAPAN + newWord);

--- a/src/main/java/dev/backend/wakuwaku/global/infra/google/places/old/textsearch/GooglePlacesTextSearchService.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/google/places/old/textsearch/GooglePlacesTextSearchService.java
@@ -13,7 +13,6 @@ import org.springframework.web.client.RestClient;
 import java.util.Collections;
 import java.util.List;
 
-import static dev.backend.wakuwaku.global.exception.WakuWakuException.INVALID_SEARCH_WORD;
 import static dev.backend.wakuwaku.global.exception.WakuWakuException.NOT_EXISTED_NEXT_PAGE_TOKEN;
 import static dev.backend.wakuwaku.global.infra.google.places.old.textsearch.dto.request.TextSearchRequest.NEXT_PAGE_URL;
 import static dev.backend.wakuwaku.global.infra.google.places.old.textsearch.dto.request.TextSearchRequest.TEXT_SEARCH_URL;
@@ -29,10 +28,6 @@ public class GooglePlacesTextSearchService{
     private String apiKey;
 
     public List<Result> textSearch(String searchWord) {
-        if (searchWord == null || searchWord.isEmpty()) {
-            throw INVALID_SEARCH_WORD;
-        }
-
         TextSearchResponse responseByTextSearch = restClient.get()
                 .uri(textSearchURI(searchWord))
                 .retrieve()

--- a/src/test/java/dev/backend/wakuwaku/global/infra/google/places/old/textsearch/GooglePlacesTextSearchServiceTest.java
+++ b/src/test/java/dev/backend/wakuwaku/global/infra/google/places/old/textsearch/GooglePlacesTextSearchServiceTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 @RestClientTest(value = {GooglePlacesTextSearchService.class, GooglePlacesPhotoService.class})
@@ -74,28 +73,6 @@ class GooglePlacesTextSearchServiceTest {
             assertThat(result.getGeometry().getLocation()).isNotNull();
             assertThat(result.getPhotos()).hasSizeLessThanOrEqualTo(1);
         }
-    }
-
-    @DisplayName("검색어 입력 없이 API 요청 시 INVALID_SEARCH_WORD 예외를 반환해야 한다.")
-    @Test
-    void failTextSearchByNoSearchWord() {
-        // given
-        mockServer
-                .expect(requestTo(textSearchURI("")))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withBadRequest());
-
-        // when
-        Throwable thrown = catchException(
-                () -> googlePlacesTextSearchService.textSearch("")
-        );
-
-
-        // then
-        assertThat(thrown)
-                .isInstanceOf(WakuWakuException.class)
-                .extracting("status")
-                .isEqualTo(ExceptionStatus.INVALID_SEARCH_WORD);
     }
 
     @DisplayName("Next Page Token 값이 없거나 비었으면 NOT_EXISTED_NEXT_PAGE_TOKEN 예외가 발생한다.")


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #55 


## 작업 내용(기대 효과)
검색어를 입력하지 않거나 빈 칸 혹은 탭만 있을 시 예외 발생

## 기타 사항
