### PR TITLE
[#57] Refactor: Response 형태 수정 및 Response 필드 수정, CORS 허용

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/domain/restaurant/dto/response/Location.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/restaurant/dto/response/Location.java
@@ -1,0 +1,16 @@
+package dev.backend.wakuwaku.domain.restaurant.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Location {
+    private final double lat;
+    private final double lng;
+
+    @Builder
+    public Location(double lat, double lng) {
+        this.lat = lat;
+        this.lng = lng;
+    }
+}

--- a/src/main/java/dev/backend/wakuwaku/domain/restaurant/dto/response/SimpleInfoRestaurantResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/restaurant/dto/response/SimpleInfoRestaurantResponse.java
@@ -11,8 +11,7 @@ public class SimpleInfoRestaurantResponse {
     private final String name;
     private final Number rating;
     private final Number userRatingsTotal;
-    private final double lat;
-    private final double lng;
+    private final Location location;
     private final List<String> photoUrl;
 
     public SimpleInfoRestaurantResponse(Restaurant restaurant) {
@@ -20,8 +19,10 @@ public class SimpleInfoRestaurantResponse {
         this.name = restaurant.getName();
         this.rating = restaurant.getRating();
         this.userRatingsTotal = restaurant.getUserRatingsTotal();
-        this.lat = restaurant.getLat();
-        this.lng = restaurant.getLng();
+        this.location = Location.builder()
+                            .lat(restaurant.getLat())
+                            .lng(restaurant.getLng())
+                            .build();
         this.photoUrl = restaurant.getPhotos();
     }
 }

--- a/src/main/java/dev/backend/wakuwaku/global/config/CorsConfig.java
+++ b/src/main/java/dev/backend/wakuwaku/global/config/CorsConfig.java
@@ -10,6 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("https://wakuwaku-jp.vercel.app/")
                 .allowedMethods("*");
     }
 }

--- a/src/main/java/dev/backend/wakuwaku/global/response/BaseResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/global/response/BaseResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 
 @Getter
 public class BaseResponse<T> {
-    private final Boolean isSuccess;
     private final int code;
     private final String message;
 
@@ -15,7 +14,6 @@ public class BaseResponse<T> {
 
     // 성공 시 반환할 데이터가 있을 때 반환되는 Response
     public BaseResponse(T data) {
-        this.isSuccess = true;
         this.code = 1000;
         this.message = "요청에 성공하였습니다.";
         this.data = data;
@@ -23,14 +21,12 @@ public class BaseResponse<T> {
 
     // 성공 시 반환할 데이터가 없을 때 반환되는 Response
     public BaseResponse() {
-        this.isSuccess = true;
         this.code = 1000;
         this.message = "요청에 성공하였습니다.";
     }
 
     // 실패 시 반환되는 Response
     public BaseResponse(ExceptionStatus status) {
-        this.isSuccess = false;
         this.code = status.getCode();
         this.message = status.getMessage();
     }

--- a/src/test/java/dev/backend/wakuwaku/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/restaurant/controller/RestaurantControllerTest.java
@@ -127,8 +127,8 @@ class RestaurantControllerTest {
                 .andExpect(jsonPath("data[*].name").exists())
                 .andExpect(jsonPath("data[*].rating").exists())
                 .andExpect(jsonPath("data[*].userRatingsTotal").exists())
-                .andExpect(jsonPath("data[*].lat").exists())
-                .andExpect(jsonPath("data[*].lng").exists())
+                .andExpect(jsonPath("data[*].location.lat").exists())
+                .andExpect(jsonPath("data[*].location.lng").exists())
                 .andExpect(jsonPath("data[*].photoUrl").exists())
                 .andDo(MockMvcRestDocumentationWrapper.document("get simple info",
                         resource(ResourceSnippetParameters.builder()
@@ -139,15 +139,14 @@ class RestaurantControllerTest {
                                         parameterWithName("search").description("검색어")
                                 )
                                 .responseFields(
-                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 성공 시 반환되는 code 값"),
-                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 성공 시 반환되는 메시지"),
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 시 반환되는 code 값"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 시 반환되는 메시지"),
                                         fieldWithPath("data[].placeId").type(JsonFieldType.STRING).description("Details Info 에 활용할 식당의 Place Id"),
                                         fieldWithPath("data[].name").type(JsonFieldType.STRING).description("식당 이름"),
                                         fieldWithPath("data[].rating").type(JsonFieldType.NUMBER).optional().description("식당 별점"),
                                         fieldWithPath("data[].userRatingsTotal").type(JsonFieldType.NUMBER).optional().description("식당 총 리뷰 수"),
-                                        fieldWithPath("data[].lat").type(JsonFieldType.NUMBER).description("위도"),
-                                        fieldWithPath("data[].lng").type(JsonFieldType.NUMBER).description("경도"),
+                                        fieldWithPath("data[].location.lat").type(JsonFieldType.NUMBER).description("위도"),
+                                        fieldWithPath("data[].location.lng").type(JsonFieldType.NUMBER).description("경도"),
                                         fieldWithPath("data[].photoUrl").type(JsonFieldType.ARRAY).optional().description("식당 대표 사진 URL"))
                                 .build()
                         )
@@ -197,9 +196,8 @@ class RestaurantControllerTest {
                                     parameterWithName("placeId").description("Details Info를 얻고 싶은 식당의 Place Id")
                                     )
                                     .responseFields(
-                                            fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
-                                            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 성공 시 반환되는 code 값"),
-                                            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 성공 시 반환되는 메시지"),
+                                            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 시 반환되는 code 값"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 시 반환되는 메시지"),
                                             fieldWithPath("data.name").type(JsonFieldType.STRING).description("식당 이름"),
                                             fieldWithPath("data.editorialSummary").type(JsonFieldType.STRING).optional().description("식당에 대한 간단한 소개글"),
                                             fieldWithPath("data.photos").type(JsonFieldType.ARRAY).optional().description("식당 사진 (최대 10개)"),


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [x] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #57

## 작업 내용(기대 효과)
- ### `Simple Info 응답 데이터 형태 중 위도와 경도를 location으로 묶어서 반환`
![image](https://github.com/AK-47-GrandMother/WakuWaku-BackEnd/assets/93212863/9a2ff44d-66cd-447d-92eb-5f2b1634d4f4)
![image](https://github.com/AK-47-GrandMother/WakuWaku-BackEnd/assets/93212863/5fb55a3d-df9f-44d6-ab62-79fce79d9a60)



- ### `응답 데이터 형태에서 응답 성공 여부 필드 삭제`
![image](https://github.com/AK-47-GrandMother/WakuWaku-BackEnd/assets/93212863/66dedff9-9325-427a-af85-a6796cfb9f64)

  - 응답 예시
![image](https://github.com/AK-47-GrandMother/WakuWaku-BackEnd/assets/93212863/c4711937-8d88-4479-867d-b7b33374acfd)



- ### `프론트엔드 작업 사이트 CORS 허용`