### PR TITLE
[#78] Feat: 검색 결과 데이터 중 찜 식당 판별을 위해 placeId 리스트 반환

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/domain/likes/controller/LikesController.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/controller/LikesController.java
@@ -20,7 +20,7 @@ public class LikesController {
     public BaseResponse<LikesResponse> pushLikes(@RequestBody LikesRequest likesRequest) {
         Likes likes = likesService.addLikes(likesRequest.getMemberId(), likesRequest.getRestaurantId());
 
-        LikesResponse response = new LikesResponse(likes.getId());
+        LikesResponse response = new LikesResponse(likes);
 
         return new BaseResponse<>(response);
     }

--- a/src/main/java/dev/backend/wakuwaku/domain/likes/dto/response/LikesResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/dto/response/LikesResponse.java
@@ -1,5 +1,6 @@
 package dev.backend.wakuwaku.domain.likes.dto.response;
 
+import dev.backend.wakuwaku.domain.likes.entity.Likes;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,8 +9,7 @@ import lombok.NoArgsConstructor;
 public class LikesResponse {
     private Long likeId;
 
-    public LikesResponse(Long likeId) {
-        this.likeId = likeId;
+    public LikesResponse(Likes likes) {
+        this.likeId = likes.getId();
     }
-
 }

--- a/src/main/java/dev/backend/wakuwaku/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/repository/LikesRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +14,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     @Query("SELECT l FROM Likes l WHERE l.member.id = :memberId AND l.restaurant.id = :restaurantId")
     Optional<Likes> findByMemberIdAndRestaurantId(@Param("memberId") Long memberId, @Param("restaurantId") Long restaurantId);
+
+    List<Likes> findByMemberId(Long memberId);
 }

--- a/src/main/java/dev/backend/wakuwaku/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/repository/LikesRepository.java
@@ -15,5 +15,5 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Query("SELECT l FROM Likes l WHERE l.member.id = :memberId AND l.restaurant.id = :restaurantId")
     Optional<Likes> findByMemberIdAndRestaurantId(@Param("memberId") Long memberId, @Param("restaurantId") Long restaurantId);
 
-    List<Likes> findByMemberId(Long memberId);
+    List<Likes> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/dev/backend/wakuwaku/domain/likes/service/LikesService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/service/LikesService.java
@@ -85,7 +85,7 @@ public class LikesService {
     }
 
     public List<String> getLikedRestaurantPlaceIds(Member member) {
-        List<Likes> likesList = likesRepository.findByMemberId(member.getId());
+        List<Likes> likesList = likesRepository.findAllByMemberId(member.getId());
 
         if (likesList == null || likesList.isEmpty()) {
             return new ArrayList<>();

--- a/src/main/java/dev/backend/wakuwaku/domain/likes/service/LikesService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/likes/service/LikesService.java
@@ -12,6 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static dev.backend.wakuwaku.global.exception.WakuWakuException.*;
 
 @Service
@@ -81,6 +84,16 @@ public class LikesService {
         return newLikes;
     }
 
+    public List<String> getLikedRestaurantPlaceIds(Member member) {
+        List<Likes> likesList = likesRepository.findByMemberId(member.getId());
 
+        if (likesList == null || likesList.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return likesList.stream()
+                .map(likes -> likes.getRestaurant().getPlaceId())
+                .toList();
+    }
 }
 

--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/controller/OauthController.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/controller/OauthController.java
@@ -1,6 +1,9 @@
 package dev.backend.wakuwaku.domain.oauth.controller;
 
+import dev.backend.wakuwaku.domain.likes.service.LikesService;
+import dev.backend.wakuwaku.domain.member.entity.Member;
 import dev.backend.wakuwaku.domain.oauth.dto.request.LoginRequest;
+import dev.backend.wakuwaku.domain.oauth.dto.response.OAuthLoginResponse;
 import dev.backend.wakuwaku.domain.oauth.service.OauthService;
 import dev.backend.wakuwaku.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -9,20 +12,24 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class OauthController {
-
     private final OauthService oauthService;
 
-    @PostMapping("/login")
-    BaseResponse<Map<String, Long>> login(@RequestBody LoginRequest loginRequest) {
+    private final LikesService likesService;
 
-        Map<String, Long> login = oauthService.login(loginRequest.getOauthServerType(), loginRequest.getCode());
-        return new BaseResponse<>(login);
+    @PostMapping("/login")
+    BaseResponse<OAuthLoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        Member member = oauthService.login(loginRequest.getOauthServerType(), loginRequest.getCode());
+        List<String> placeIdOfLikesRestaurants = likesService.getLikedRestaurantPlaceIds(member);
+
+        return new BaseResponse<>(OAuthLoginResponse.builder()
+                .id(member.getId())
+                .likedRestaurantPlaceIds(placeIdOfLikesRestaurants)
+                .build());
     }
 }
-

--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/dto/response/OAuthLoginResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/dto/response/OAuthLoginResponse.java
@@ -1,0 +1,21 @@
+package dev.backend.wakuwaku.domain.oauth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OAuthLoginResponse {
+    private Long id;
+    private List<String> likedRestaurantPlaceIds = new ArrayList<>();
+
+    @Builder
+    public OAuthLoginResponse(Long id, List<String> likedRestaurantPlaceIds) {
+        this.id = id;
+        this.likedRestaurantPlaceIds = likedRestaurantPlaceIds;
+    }
+}

--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
@@ -12,24 +12,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class OauthService {
-
     private final OauthMemberClientComposite oauthMemberClientComposite;
+
     private final MemberRepository memberRepository;
 
-
-
-    public Map<String, Long> login(OauthServerType oauthServerType, String authCode) {
+    public Member login(OauthServerType oauthServerType, String authCode) {
         OauthMember oauthMember;
+
         try {
             oauthMember = oauthMemberClientComposite.fetch(oauthServerType, authCode);
+
         } catch (Exception e) {
             log.error("Failed to fetch OAuth member: {}", e.getMessage(), e);
             throw WakuWakuException.FAILED_TO_LOGIN;
@@ -54,8 +51,6 @@ public class OauthService {
             member.updateCheckstatus("Y");
         }
 
-        Map<String, Long> response = new HashMap<>();
-        response.put("id", member.getId());
-        return response;
+        return member;
     }
 }

--- a/src/main/java/dev/backend/wakuwaku/global/infra/redis/config/RedisConfig.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/redis/config/RedisConfig.java
@@ -1,21 +1,14 @@
 package dev.backend.wakuwaku.global.infra.redis.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
 
 /**
  * yml 파일에 정의한 내용을 기반으로 Redis 클라이언트를 구성하기 위한 Configuration 클래스
@@ -24,7 +17,6 @@ import java.time.Duration;
  * 때문에, @EnableCaching 어노테이션을 설정 클래스에 추가해주어야 한다
  */
 @Configuration
-@EnableCaching
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String redisHost;
@@ -46,28 +38,6 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
-    /**
-     * 캐시 만료 시간을 3일로 설정
-     * <p>enableTimeToIdle() 을 추가하여 캐시 히트 시 캐시 만료 시간(TTL) 갱신
-     * <p>1. 캐시를 관리하고 캐시 된 ‘데이터를 저장’하고 ‘반환’하는 역할
-     * <p>2. 일반적으로 메모리 상에 저장되는 데이터를 디스크, 데이터베이스, 클라우드 서비스와 같은 저장소에 저장이 가능하도록 함
-     * <p>3. 해당 캐시는 Redis, Ehcache, Caffeine 등 다양한 캐시 라이브러리와 연동하여 사용할 수 있음
-     */
-    @Bean
-    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
-
-        RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofDays(3))
-                .enableTimeToIdle();
-
-        return RedisCacheManager.RedisCacheManagerBuilder
-                .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(conf)
-                .build();
-    }
-
     @Bean
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -76,13 +46,6 @@ public class RedisConfig {
         // 일반적인 key:value의 경우 시리얼라이저
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
-//        // Hash를 사용할 경우 시리얼라이저
-//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
-//
-//        // 모든 경우
-//        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
@@ -150,6 +150,7 @@ class LikesServiceTest {
     }
 
     @DisplayName("멤버 Id로 해당 멤버의 찜 목록 PlaceId 반환")
+    @Test
     void getLikedRestaurantPlaceIds() {
         // given
         Member member = createMember(1);
@@ -183,6 +184,26 @@ class LikesServiceTest {
         assertThat(likedRestaurantPlaceIds.get(2)).isEqualTo(PLACE_ID);
         assertThat(likedRestaurantPlaceIds.get(3)).isEqualTo(PLACE_ID);
         assertThat(likedRestaurantPlaceIds.get(4)).isEqualTo(PLACE_ID);
+    }
+
+    @DisplayName("멤버 Id로 해당 멤버의 찜 목록이 비어있을 때 빈 리스트를 반환")
+    @Test
+    void NoHaveLikedRestaurant() {
+        // given
+        Member member = createMember(1);
+        member.createId(MEMBER_ID);
+
+        List<Likes> likesList = new ArrayList<>();
+
+        given(likesRepository.findByMemberId(MEMBER_ID)).willReturn(likesList);
+
+        // when
+        List<String> likedRestaurantPlaceIds = likesService.getLikedRestaurantPlaceIds(member);
+
+        // then
+        then(likesRepository).should().findByMemberId(MEMBER_ID);
+
+        assertThat(likedRestaurantPlaceIds).isEmpty();
     }
 
     private Member createMember(int number) {

--- a/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
@@ -13,7 +13,6 @@ import dev.backend.wakuwaku.domain.restaurant.repository.RestaurantRepository;
 import dev.backend.wakuwaku.global.exception.WakuWakuException;
 import dev.backend.wakuwaku.global.infra.google.places.dto.*;
 import org.assertj.core.api.BDDAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,16 +28,18 @@ import static dev.backend.wakuwaku.global.exception.ExceptionStatus.ALREADY_LIKE
 import static dev.backend.wakuwaku.global.exception.ExceptionStatus.LIKE_NOT_FOUND_EXCEPTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.BDDMockito.when;
+import static org.mockito.BDDMockito.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class LikesServiceTest {
 
     @InjectMocks
-    private LikesService likeService;
+    private LikesService likesService;
 
     @Mock
-    private LikesRepository likeRepository;
+    private LikesRepository likesRepository;
 
     @Mock
     private MemberRepository memberRepository;
@@ -46,13 +47,12 @@ class LikesServiceTest {
     @Mock
     private RestaurantRepository restaurantRepository;
 
-    private Member testMember;
-    private Restaurant testRestaurant;
     private static final String PLACE_ID = "ChIJAQCl79GMGGARZheneHqgIUs";
 
     private static final String NAME = "우동신";
 
     private static final int TOTAL_PAGE = 5;
+
     private static final String MEMBER_EMAIL = "m@m.com";
 
     private final List<Photo> photos = new ArrayList<>();
@@ -61,18 +61,143 @@ class LikesServiceTest {
 
     private Places places;
 
-    @BeforeEach
-    void setUp() {
-        testMember = Member.builder()
+    private static final Long MEMBER_ID = 1L;
+
+    private static final Long RESTAURANT_ID = 1L;
+
+    private static final String NICKNAME = "MIN";
+
+    @Test
+    @DisplayName("찜 추가 성공 테스트")
+    void addLikes_Success() {
+        // given
+        int number = 1;
+
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(createMember(number)));
+        when(restaurantRepository.findById(RESTAURANT_ID)).thenReturn(Optional.of(createRestaurant(number)));
+        when(likesRepository.findByMemberIdAndRestaurantId(MEMBER_ID, RESTAURANT_ID)).thenReturn(Optional.empty());
+
+        // when
+        Likes like = likesService.addLikes(MEMBER_ID, RESTAURANT_ID);
+
+        // then
+        assertNotNull(like); // like가 null이 아닌지 확인합니다.
+        assertEquals(MEMBER_EMAIL, like.getMember().getEmail()); // assertEquals를 사용하여 값 비교
+        assertEquals(NICKNAME + number, like.getMember().getNickname());
+        assertEquals(PLACE_ID, like.getRestaurant().getPlaceId());
+        assertEquals(number, like.getRestaurant().getRating());
+
+        assertEquals((LikesStatusType.Y), like.getLikesStatus());
+
+    }
+
+    @Test
+    @DisplayName("이미 찜한 경우 예외 발생 테스트")
+    void addLikes_AlreadyLikesd() {
+        // given
+        Likes existingLikes = Likes.builder()
+                .member(createMember(1))
+                .restaurant(createRestaurant(1))
+                .likesStatus(LikesStatusType.Y)
+                .build();
+        when(likesRepository.findByMemberIdAndRestaurantId(MEMBER_ID, RESTAURANT_ID)).thenReturn(Optional.of(existingLikes));
+
+
+        // when & then
+        BDDAssertions.thenThrownBy(
+                        () -> likesService.addLikes(MEMBER_ID, RESTAURANT_ID)
+                )
+                .isInstanceOf(WakuWakuException.class)
+                .extracting("status")
+                .isEqualTo(ALREADY_LIKED_EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("찜 삭제 성공 테스트")
+    void deleteLikes_Success() {
+        // given
+        Likes existingLikes = Likes.builder()
+                .member(createMember(1))
+                .restaurant(createRestaurant(1))
+                .likesStatus(LikesStatusType.Y)
+                .build();
+
+        when(likesRepository.findByMemberIdAndRestaurantId(MEMBER_ID, RESTAURANT_ID)).thenReturn(Optional.of(existingLikes));
+
+        // when
+        likesService.deleteLikes(MEMBER_ID, RESTAURANT_ID); // 반환값 검증이 아닌 메소드 호출 자체를 테스트
+
+        // then
+        assertEquals(LikesStatusType.N, existingLikes.getLikesStatus()); // 상태가 변경되었는지 검증
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 찜 삭제 시 예외 발생 테스트")
+    void deleteLikes_NotFound() {
+        // given
+        when(likesRepository.findByMemberIdAndRestaurantId(MEMBER_ID, RESTAURANT_ID)).thenReturn(Optional.empty());
+
+        // when & then
+
+        // --
+        //assertThrows(LIKE_NOT_FOUND_EXCEPTION.getClass(), () -> likeService.deleteLikes(memberId, restaurantId));
+        BDDAssertions.thenThrownBy(
+                () -> likesService.deleteLikes(MEMBER_ID, RESTAURANT_ID)
+        )
+                .isInstanceOf(WakuWakuException.class)
+                .extracting("status")
+                .isEqualTo(LIKE_NOT_FOUND_EXCEPTION);
+    }
+
+    @DisplayName("멤버 Id로 해당 멤버의 찜 목록 PlaceId 반환")
+    void getLikedRestaurantPlaceIds() {
+        // given
+        Member member = createMember(1);
+        member.createId(MEMBER_ID);
+
+        Restaurant restaurant1 = createRestaurant(1);
+        Restaurant restaurant2 = createRestaurant(2);
+        Restaurant restaurant3 = createRestaurant(3);
+        Restaurant restaurant4 = createRestaurant(4);
+        Restaurant restaurant5 = createRestaurant(5);
+
+
+        List<Likes> likesList = new ArrayList<>();
+        likesList.add(createLikes(member, restaurant1));
+        likesList.add(createLikes(member, restaurant2));
+        likesList.add(createLikes(member, restaurant3));
+        likesList.add(createLikes(member, restaurant4));
+        likesList.add(createLikes(member, restaurant5));
+
+        given(likesRepository.findByMemberId(MEMBER_ID)).willReturn(likesList);
+
+        // when
+        List<String> likedRestaurantPlaceIds = likesService.getLikedRestaurantPlaceIds(member);
+
+        // then
+        then(likesRepository).should().findByMemberId(MEMBER_ID);
+
+        assertThat(likedRestaurantPlaceIds).hasSize(5);
+        assertThat(likedRestaurantPlaceIds.get(0)).isEqualTo(PLACE_ID);
+        assertThat(likedRestaurantPlaceIds.get(1)).isEqualTo(PLACE_ID);
+        assertThat(likedRestaurantPlaceIds.get(2)).isEqualTo(PLACE_ID);
+        assertThat(likedRestaurantPlaceIds.get(3)).isEqualTo(PLACE_ID);
+        assertThat(likedRestaurantPlaceIds.get(4)).isEqualTo(PLACE_ID);
+    }
+
+    private Member createMember(int number) {
+        return Member.builder()
                 .oauthServerId("testId")
                 .email(MEMBER_EMAIL)
                 .role(Role.USER)
-                .nickname("MIN")
+                .nickname(NICKNAME + number)
                 .oauthServerType(OauthServerType.NAVER)
                 .birthday("19990118")
                 .profileImageUrl("www.d.com")
                 .build();
+    }
 
+    private Restaurant createRestaurant(int number) {
         dev.backend.wakuwaku.global.infra.google.places.dto.DisplayName name = new dev.backend.wakuwaku.global.infra.google.places.dto.DisplayName(NAME);
 
         Location location = new Location(35.686489, 139.697001);
@@ -106,7 +231,7 @@ class LikesServiceTest {
         places = Places.builder()
                 .id(PLACE_ID)
                 .displayName(name)
-                .rating(4.1)
+                .rating(number)
                 .location(location)
                 .currentOpeningHours(currentOpeningHours)
                 .photos(photos)
@@ -128,92 +253,14 @@ class LikesServiceTest {
                 .servesVegetarianFood(false)
                 .build();
 
-        testRestaurant = new Restaurant(places);
+        return new Restaurant(places);
     }
 
-    @Test
-    @DisplayName("찜 추가 성공 테스트")
-    void addLikes_Success() {
-        // given
-        Long memberId = 1L;
-        Long restaurantId = 1L;
-
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
-        when(restaurantRepository.findById(restaurantId)).thenReturn(Optional.of(testRestaurant));
-        when(likeRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)).thenReturn(Optional.empty());
-
-
-        // when
-        Likes like = likeService.addLikes(memberId, restaurantId);
-
-        // then
-        assertNotNull(like); // like가 null이 아닌지 확인합니다.
-        assertEquals(MEMBER_EMAIL, like.getMember().getEmail()); // assertEquals를 사용하여 값 비교
-        assertEquals(PLACE_ID, like.getRestaurant().getPlaceId());
-        assertEquals((LikesStatusType.Y), like.getLikesStatus());
-
-    }
-
-    @Test
-    @DisplayName("이미 찜한 경우 예외 발생 테스트")
-    void addLikes_AlreadyLikesd() {
-        // given
-        Long memberId = 1L;
-        Long restaurantId = 1L;
-        Likes existingLikes = Likes.builder()
-                .member(testMember)
-                .restaurant(testRestaurant)
+    private Likes createLikes(Member member, Restaurant restaurant) {
+        return Likes.builder()
+                .member(member)
+                .restaurant(restaurant)
                 .likesStatus(LikesStatusType.Y)
                 .build();
-        when(likeRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)).thenReturn(Optional.of(existingLikes));
-
-
-        // when & then
-        BDDAssertions.thenThrownBy(
-                        () -> likeService.addLikes(memberId, restaurantId)
-                )
-                .isInstanceOf(WakuWakuException.class)
-                .extracting("status")
-                .isEqualTo(ALREADY_LIKED_EXCEPTION);
-    }
-
-    @Test
-    @DisplayName("찜 삭제 성공 테스트")
-    void deleteLikes_Success() {
-        // given
-        Long memberId = 1L;
-        Long restaurantId = 1L;
-        Likes existingLikes = Likes.builder()
-                .member(testMember)
-                .restaurant(testRestaurant)
-                .likesStatus(LikesStatusType.Y)
-                .build();
-        when(likeRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)).thenReturn(Optional.of(existingLikes));
-
-        // when
-        likeService.deleteLikes(memberId, restaurantId); // 반환값 검증이 아닌 메소드 호출 자체를 테스트
-
-        // then
-        assertEquals(LikesStatusType.N, existingLikes.getLikesStatus()); // 상태가 변경되었는지 검증
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 찜 삭제 시 예외 발생 테스트")
-    void deleteLikes_NotFound() {
-        // given
-        Long memberId = 1L;
-        Long restaurantId = 1L;
-        when(likeRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)).thenReturn(Optional.empty());
-
-        // when & then
-
-        // --
-        //assertThrows(LIKE_NOT_FOUND_EXCEPTION.getClass(), () -> likeService.deleteLikes(memberId, restaurantId));
-        BDDAssertions.thenThrownBy(
-                () -> likeService.deleteLikes(memberId, restaurantId)
-        )
-                .isInstanceOf(WakuWakuException.class)
-                .extracting("status")
-                .isEqualTo(LIKE_NOT_FOUND_EXCEPTION);
     }
 }

--- a/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/like/service/LikesServiceTest.java
@@ -170,13 +170,13 @@ class LikesServiceTest {
         likesList.add(createLikes(member, restaurant4));
         likesList.add(createLikes(member, restaurant5));
 
-        given(likesRepository.findByMemberId(MEMBER_ID)).willReturn(likesList);
+        given(likesRepository.findAllByMemberId(MEMBER_ID)).willReturn(likesList);
 
         // when
         List<String> likedRestaurantPlaceIds = likesService.getLikedRestaurantPlaceIds(member);
 
         // then
-        then(likesRepository).should().findByMemberId(MEMBER_ID);
+        then(likesRepository).should().findAllByMemberId(MEMBER_ID);
 
         assertThat(likedRestaurantPlaceIds).hasSize(5);
         assertThat(likedRestaurantPlaceIds.get(0)).isEqualTo(PLACE_ID);
@@ -195,13 +195,13 @@ class LikesServiceTest {
 
         List<Likes> likesList = new ArrayList<>();
 
-        given(likesRepository.findByMemberId(MEMBER_ID)).willReturn(likesList);
+        given(likesRepository.findAllByMemberId(MEMBER_ID)).willReturn(likesList);
 
         // when
         List<String> likedRestaurantPlaceIds = likesService.getLikedRestaurantPlaceIds(member);
 
         // then
-        then(likesRepository).should().findByMemberId(MEMBER_ID);
+        then(likesRepository).should().findAllByMemberId(MEMBER_ID);
 
         assertThat(likedRestaurantPlaceIds).isEmpty();
     }

--- a/src/test/java/dev/backend/wakuwaku/domain/oauth/service/OauthServiceTest.java
+++ b/src/test/java/dev/backend/wakuwaku/domain/oauth/service/OauthServiceTest.java
@@ -8,7 +8,6 @@ import dev.backend.wakuwaku.domain.oauth.dto.OauthServerType;
 import dev.backend.wakuwaku.global.exception.ExceptionStatus;
 import dev.backend.wakuwaku.global.exception.WakuWakuException;
 import dev.backend.wakuwaku.global.infra.oauth.client.OauthMemberClientComposite;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,20 +15,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class OauthServiceTest {
-
-
     @Mock
     private OauthMemberClientComposite oauthMemberClientComposite;
 
@@ -45,17 +40,16 @@ class OauthServiceTest {
     private static final String PROFILE_IMAGE_URL = "https://example.com/profile.jpg";
     private static final String BIRTHDAY = "1990-01-01";
 
-    @BeforeEach
-    void setUp() {
-    }
-
     @Test
     @DisplayName("로그인 성공 시 회원 정보 반환")
     void loginSuccess() {
         // Given
         OauthServerType oauthServerType = OauthServerType.KAKAO;
+
         OauthId oauthId = new OauthId("test_oauth_server_id", oauthServerType);
+
         OauthMember oauthMember = new OauthMember(oauthId, NICKNAME, PROFILE_IMAGE_URL, EMAIL, BIRTHDAY);
+
         Member newMember = Member.builder()
                 .oauthServerId(oauthId.getOauthServerId())
                 .oauthServerType(oauthId.getOauthServerType())
@@ -65,16 +59,25 @@ class OauthServiceTest {
                 .profileImageUrl(PROFILE_IMAGE_URL)
                 .build();
 
-        given(oauthMemberClientComposite.fetch(eq(oauthServerType), eq(AUTH_CODE))).willReturn(oauthMember);
-        given(memberRepository.findByEmail(eq(EMAIL))).willReturn(Optional.empty());
+        given(oauthMemberClientComposite.fetch(oauthServerType, AUTH_CODE)).willReturn(oauthMember);
+        given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
         given(memberRepository.save(any(Member.class))).willReturn(newMember);
 
         // When
-        Map<String, Long> response = oauthService.login(oauthServerType, AUTH_CODE);
+        Member member = oauthService.login(oauthServerType, AUTH_CODE);
 
         // Then
-        assertThat(response).isNotNull();
-        assertThat(response).containsKeys("id");
+        assertThat(member).isNotNull();
+
+        assertThat(member.getId()).isEqualTo(newMember.getId());
+        assertThat(member.getOauthServerType()).isEqualTo(newMember.getOauthServerType());
+        assertThat(member.getOauthServerId()).isEqualTo(newMember.getOauthServerId());
+        assertThat(member.getEmail()).isEqualTo(newMember.getEmail());
+        assertThat(member.getBirthday()).isEqualTo(newMember.getBirthday());
+        assertThat(member.getNickname()).isEqualTo(newMember.getNickname());
+        assertThat(member.getProfileImageUrl()).isEqualTo(newMember.getProfileImageUrl());
+        assertThat(member.getRole()).isEqualTo(newMember.getRole());
+
         then(memberRepository).should().save(any(Member.class));
     }
 
@@ -83,8 +86,11 @@ class OauthServiceTest {
     void loginExistingMember() {
         // Given
         OauthServerType oauthServerType = OauthServerType.KAKAO;
+
         OauthId oauthId = new OauthId("dummy_oauth_server_id", oauthServerType);
+
         OauthMember oauthMember = new OauthMember(oauthId, NICKNAME, PROFILE_IMAGE_URL, EMAIL, BIRTHDAY);
+
         Member existingMember = Member.builder()
                 .email(EMAIL)
                 .nickname(NICKNAME)
@@ -93,19 +99,27 @@ class OauthServiceTest {
                 .build();
 
         existingMember.createId(1L);
-        existingMember.setCheckStatus("N");
+        existingMember.createCheckstatus("N");
 
-        given(oauthMemberClientComposite.fetch(eq(oauthServerType), eq(AUTH_CODE))).willReturn(oauthMember);
-        given(memberRepository.findByEmail(eq(EMAIL))).willReturn(Optional.of(existingMember));
+        given(oauthMemberClientComposite.fetch(oauthServerType, AUTH_CODE)).willReturn(oauthMember);
+        given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(existingMember));
 
         // When
-        Map<String, Long> response = oauthService.login(oauthServerType, AUTH_CODE);
+        Member member = oauthService.login(oauthServerType, AUTH_CODE);
 
         // Then
-        assertThat(response).isNotNull();
-        assertThat(response).containsKeys("id");
-        assertThat(response.get("id")).isEqualTo(existingMember.getId());
+        assertThat(member).isNotNull();
+
+        assertThat(member.getId()).isEqualTo(existingMember.getId());
+        assertThat(member.getOauthServerType()).isEqualTo(existingMember.getOauthServerType());
+        assertThat(member.getOauthServerId()).isEqualTo(existingMember.getOauthServerId());
+        assertThat(member.getEmail()).isEqualTo(existingMember.getEmail());
+        assertThat(member.getBirthday()).isEqualTo(existingMember.getBirthday());
+        assertThat(member.getNickname()).isEqualTo(existingMember.getNickname());
+        assertThat(member.getProfileImageUrl()).isEqualTo(existingMember.getProfileImageUrl());
+        assertThat(member.getRole()).isEqualTo(existingMember.getRole());
         assertThat(existingMember.getCheckStatus()).isEqualTo("Y");
+
         then(memberRepository).should().findByEmail(EMAIL);
     }
 
@@ -115,7 +129,7 @@ class OauthServiceTest {
         // Given
         OauthServerType oauthServerType = OauthServerType.KAKAO;
 
-        given(oauthMemberClientComposite.fetch(eq(oauthServerType), eq(AUTH_CODE))).willThrow(new RuntimeException("OAuth client error"));
+        given(oauthMemberClientComposite.fetch(oauthServerType, AUTH_CODE)).willThrow(new RuntimeException("OAuth client error"));
 
         // When / Then
         assertThatThrownBy(() -> oauthService.login(oauthServerType, AUTH_CODE))


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경
- [x] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #78

## 작업 내용(기대 효과)
### OauthController
로그인 시 반환되는 데이터에 해당 회원의 찜한 식당의 placeId 리스트도 같이 반환하도록 구현하여 검색 결과 화면에서 찜이 된 식당과 찜이 안 된 식당의 구분을 할 수 있게 됨.

### LikesService
MemberId로 LikesRepository의 findAllByMemberId 메서드를 호출하여 Likes 객체를 리스트로 받은 뒤, placeId만 리스트 형태로 반환하도록 구현

### LikesRepository
MemberId로 해당 회원의 찜 목록을 호출
