### PR TITLE
[#97] Refactor: 구글 계정으로 로그인 시, 사용자 닉네임을 제대로 가져오도록 구현

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/google/GoogleMemberClient.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/google/GoogleMemberClient.java
@@ -30,7 +30,10 @@ public class GoogleMemberClient implements OauthMemberClient {
         GoogleToken tokenInfo = googleApiClient.fetchToken(tokenRequestParams(authCode));
         GoogleMemberResponse googleMemberResponse = googleApiClient.fetchMember(tokenInfo.access_token());
 
-        return googleMemberResponse.toDomain();
+        String userFirstName = googleMemberResponse.getGiven_name();
+        String userLastName = googleMemberResponse.getFamily_name();
+
+        return googleMemberResponse.toDomain(getUserName(userFirstName, userLastName));
     }
 
     private MultiValueMap<String, String> tokenRequestParams(String authCode) {
@@ -45,5 +48,13 @@ public class GoogleMemberClient implements OauthMemberClient {
             params.add("resource_uri", googleOauthConfig.getResourceUri());
 
             return params;
+    }
+
+    private String getUserName(String firstName, String lastName) {
+        if (lastName == null) {
+            return firstName;
+        }
+
+        return lastName + firstName;
     }
 }

--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/google/dto/GoogleMemberResponse.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/google/dto/GoogleMemberResponse.java
@@ -22,11 +22,11 @@ public class GoogleMemberResponse {
 
     String picture;
 
-    public OauthMember toDomain() {
+    public OauthMember toDomain(String nickname) {
         return OauthMember.builder()
                           .oauthId(new OauthId(String.valueOf(id), GOOGLE))
                           .email(email)
-                          .nickname(given_name + " " + family_name)
+                          .nickname(nickname)
                           .profileImageUrl(picture)
                           .build();
     }

--- a/src/test/java/dev/backend/wakuwaku/global/infra/oauth/client/OauthMemberClientCompositeTest.java
+++ b/src/test/java/dev/backend/wakuwaku/global/infra/oauth/client/OauthMemberClientCompositeTest.java
@@ -78,7 +78,51 @@ class OauthMemberClientCompositeTest {
         // Then
         assertEquals("12345", oauthMember.getOauthId().getOauthServerId());
         assertEquals("test@gmail.com", oauthMember.getEmail());
-        assertEquals("John Doe", oauthMember.getNickname());
+        assertEquals("DoeJohn", oauthMember.getNickname());
+        assertEquals("https://example.com/picture", oauthMember.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("Oauth Login Type에 관련된 사용자 정보 가져오기(성이 null인 사용자)")
+    void testFetch_No_Last_Name() {
+        // Given
+        String mockAuthCode = "mockAuthCode";
+
+        OauthServerType oauthServerType = OauthServerType.GOOGLE;
+
+        GoogleToken mockToken = new GoogleToken("mockAccessToken", "bearer", 3600, null, "mockIdToken");
+
+        GoogleMemberResponse mockResponse = new GoogleMemberResponse("12345", "test@gmail.com", "John", null, "https://example.com/picture");
+
+        // Mock GoogleOauthConfig에서 필요한 값들 설정
+        when(mockGoogleOauthConfig.getClientId()).thenReturn("mockClientId");
+        when(mockGoogleOauthConfig.getClientSecret()).thenReturn("mockClientSecret");
+        when(mockGoogleOauthConfig.getRedirectUri()).thenReturn("mockRedirectUri");
+        when(mockGoogleOauthConfig.getTokenUri()).thenReturn("mockTokenUri");
+        when(mockGoogleOauthConfig.getResourceUri()).thenReturn("mockResourceUri");
+
+        // MultiValueMap 생성
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", mockGoogleOauthConfig.getClientId());
+        params.add("client_secret", mockGoogleOauthConfig.getClientSecret());
+        params.add("code", mockAuthCode);
+        params.add("redirect_uri", mockGoogleOauthConfig.getRedirectUri());
+        params.add("token_uri", mockGoogleOauthConfig.getTokenUri());
+        params.add("resource_uri", mockGoogleOauthConfig.getResourceUri());
+
+        // Mockito를 사용하여 fetchToken 및 fetchMember 메서드의 반환값 설정
+        when(mockGoogleApiClient.fetchToken(params)).thenReturn(mockToken);
+        when(mockGoogleApiClient.fetchMember(mockToken.access_token())).thenReturn(mockResponse);
+
+        // When
+        OauthMember oauthMember = clientComposite.fetch(oauthServerType, mockAuthCode);
+
+        // Then
+        assertEquals("12345", oauthMember.getOauthId().getOauthServerId());
+        assertEquals("test@gmail.com", oauthMember.getEmail());
+        assertEquals("John", oauthMember.getNickname());
         assertEquals("https://example.com/picture", oauthMember.getProfileImageUrl());
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [x] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #97 

## 작업 내용(기대 효과)
- 구글 계정으로 로그인 한 사용자의 성이 null 일 경우, 이름만 반환하도록 수정
- 구글 계정으로 로그인 한 사용자의 성이 존재할 경우, 성+이름으로 반환하도록 수정