### PR TITLE
[#105] Fix: 카카오 소셜 로그인 시 사용자 정보 요청 때 헤더에 content type 추가

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClient.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClient.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
 
 /**
  * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
@@ -36,7 +38,7 @@ public class KakaoMemberClient implements OauthMemberClient {
     @Override
     public OauthMember fetch(String authCode) {
         KakaoToken tokenInfo = kakaoApiClient.fetchToken(tokenRequestParams(authCode)); // (1)
-        KakaoMemberResponse kakaoMemberResponse = kakaoApiClient.fetchMember("Bearer " + tokenInfo.accessToken());  // (2)
+        KakaoMemberResponse kakaoMemberResponse = kakaoApiClient.fetchMember("Bearer " + tokenInfo.accessToken(), APPLICATION_FORM_URLENCODED_VALUE);  // (2)
 
         return kakaoMemberResponse.toDomain();  // (3)
     }

--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/client/KakaoApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 public interface KakaoApiClient {
@@ -17,5 +18,5 @@ public interface KakaoApiClient {
 
     // 추가
     @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
-    KakaoMemberResponse fetchMember(@RequestHeader(name = AUTHORIZATION) String bearerToken);
+    KakaoMemberResponse fetchMember(@RequestHeader(name = AUTHORIZATION) String bearerToken, @RequestHeader(name = CONTENT_TYPE) String contentType);
 }

--- a/src/test/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClientTest.java
+++ b/src/test/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClientTest.java
@@ -50,7 +50,7 @@ class KakaoMemberClientTest {
         );
         KakaoMemberResponse kakaoMemberResponse = new KakaoMemberResponse(123L, true, null, kakaoAccount);
 
-        when(kakaoApiClient.fetchMember(any())).thenReturn(kakaoMemberResponse);
+        when(kakaoApiClient.fetchMember(any(), any())).thenReturn(kakaoMemberResponse);
 
         // FRONT에서 넘겨주는 코드를 받아서 사용자 정보를 받아 저장함.
         OauthMember oauthMember = kakaoMemberClient.fetch("authCode");


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #105 

## 작업 내용(기대 효과)
카카오 소셜 로그인 시, 액세스 토큰을 활용하여 사용자 정보를 요청할 때, 헤더에 content-type을 추가하여 요청