### PR TITLE
[#107] HOTFIX: Kakao 소셜 로그인 에러

### DIFF
--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/controller/OauthController.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/controller/OauthController.java
@@ -7,6 +7,7 @@ import dev.backend.wakuwaku.domain.oauth.dto.response.OAuthLoginResponse;
 import dev.backend.wakuwaku.domain.oauth.service.OauthService;
 import dev.backend.wakuwaku.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/oauth")
 @RequiredArgsConstructor
+@Slf4j
 public class OauthController {
     private final OauthService oauthService;
 
@@ -24,7 +26,13 @@ public class OauthController {
 
     @PostMapping("/login")
     BaseResponse<OAuthLoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        log.info("loginRequest.getOauthServerType() = {}", loginRequest.getOauthServerType());
+        log.info("loginRequest.getCode() = {}", loginRequest.getCode());
+
         Member member = oauthService.login(loginRequest.getOauthServerType(), loginRequest.getCode());
+
+        log.info("member.getOauthServerType() = {}", member.getOauthServerType());
+
         List<String> placeIdOfLikesRestaurants = likesService.getLikedRestaurantPlaceIds(member);
 
         return new BaseResponse<>(OAuthLoginResponse.builder()

--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
@@ -27,8 +27,14 @@ public class OauthService {
         try {
             oauthMember = oauthMemberClientComposite.fetch(oauthServerType, authCode);
 
+            log.info("oauthMember.getEmail() = {}", oauthMember.getEmail());
+            log.info("oauthMember = {}", oauthMember);
+
         } catch (Exception e) {
             log.error("Failed to fetch OAuth member: {}", e.getMessage(), e);
+            log.error("OAuthService Error getCause().getMessage() = {}", e.getCause().getMessage());
+            log.error("OAuthService Error getClass().getSimpleName() = {}", e.getClass().getSimpleName());
+            log.error("OAuthService Error getMessage().getClass().getSimpleName() = {}", e.getMessage().getClass().getSimpleName());
 
             throw WakuWakuException.FAILED_TO_LOGIN;
         }

--- a/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
+++ b/src/main/java/dev/backend/wakuwaku/domain/oauth/service/OauthService.java
@@ -32,9 +32,6 @@ public class OauthService {
 
         } catch (Exception e) {
             log.error("Failed to fetch OAuth member: {}", e.getMessage(), e);
-            log.error("OAuthService Error getCause().getMessage() = {}", e.getCause().getMessage());
-            log.error("OAuthService Error getClass().getSimpleName() = {}", e.getClass().getSimpleName());
-            log.error("OAuthService Error getMessage().getClass().getSimpleName() = {}", e.getMessage().getClass().getSimpleName());
 
             throw WakuWakuException.FAILED_TO_LOGIN;
         }

--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/client/OauthMemberClientComposite.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/client/OauthMemberClientComposite.java
@@ -3,6 +3,7 @@ package dev.backend.wakuwaku.global.infra.oauth.client;
 import dev.backend.wakuwaku.domain.oauth.dto.OauthMember;
 import dev.backend.wakuwaku.domain.oauth.dto.OauthServerType;
 import dev.backend.wakuwaku.global.exception.ExceptionStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -13,6 +14,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 @Component
+@Slf4j
 public class OauthMemberClientComposite {
     private final Map<OauthServerType, OauthMemberClient> mapping;
 
@@ -25,13 +27,21 @@ public class OauthMemberClientComposite {
     }
 
     public OauthMember fetch(OauthServerType oauthServerType, String authCode) {
-        return getClient(oauthServerType).fetch(authCode);
+        OauthMember oauthMember = getClient(oauthServerType).fetch(authCode);
+
+        log.info("oauthMember.getEmail() = {}", oauthMember.getEmail());
+
+        return oauthMember;
     }
 
     private OauthMemberClient getClient(OauthServerType oauthServerType) {
-        return Optional.ofNullable(mapping.get(oauthServerType))
-                       .orElseThrow(
-                               () -> new RuntimeException(ExceptionStatus.NOT_EXISTED_SOCIAL_TYPE.getMessage())
-                       );
+        OauthMemberClient oAuthMemberClient = Optional.ofNullable(mapping.get(oauthServerType))
+                                                      .orElseThrow(
+                                                              () -> new RuntimeException(ExceptionStatus.NOT_EXISTED_SOCIAL_TYPE.getMessage())
+                                                      );
+
+        log.info("(oAuthMemberClient == null) = {}", oAuthMemberClient == null);
+
+        return oAuthMemberClient;
     }
 }

--- a/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClient.java
+++ b/src/main/java/dev/backend/wakuwaku/global/infra/oauth/kakao/KakaoMemberClient.java
@@ -7,6 +7,7 @@ import dev.backend.wakuwaku.global.infra.oauth.kakao.dto.KakaoMemberResponse;
 import dev.backend.wakuwaku.global.infra.oauth.kakao.client.KakaoApiClient;
 import dev.backend.wakuwaku.global.infra.oauth.kakao.dto.KakaoToken;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -20,6 +21,7 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class KakaoMemberClient implements OauthMemberClient {
     private final KakaoApiClient kakaoApiClient;
 
@@ -37,8 +39,17 @@ public class KakaoMemberClient implements OauthMemberClient {
      */
     @Override
     public OauthMember fetch(String authCode) {
+        log.info("KakaoMemberClient Class fetch Method authCode = {}", authCode);
+
         KakaoToken tokenInfo = kakaoApiClient.fetchToken(tokenRequestParams(authCode)); // (1)
+
+        log.info("tokenInfo.accessToken() = {}", tokenInfo.accessToken());
+        log.info("tokenInfo = {}", tokenInfo);
+
         KakaoMemberResponse kakaoMemberResponse = kakaoApiClient.fetchMember("Bearer " + tokenInfo.accessToken(), APPLICATION_FORM_URLENCODED_VALUE);  // (2)
+
+        log.info("kakaoMemberResponse.toDomain().getEmail() = {}", kakaoMemberResponse.toDomain().getEmail());
+        log.info("kakaoMemberResponse = {]", kakaoMemberResponse);
 
         return kakaoMemberResponse.toDomain();  // (3)
     }
@@ -51,6 +62,14 @@ public class KakaoMemberClient implements OauthMemberClient {
         params.add("redirect_uri", kakaoOauthConfig.getRedirectUri());
         params.add("code", authCode);
         params.add("client_secret", kakaoOauthConfig.getClientSecret());
+
+        log.info("params.get(\"grant_type\") = {}", params.get("grant_type"));
+        log.info("params.get(\"client_id\") = {}", params.get("client_id"));
+        log.info("params.get(\"redirect_uri\") = {}", params.get("redirect_uri"));
+        log.info("params.get(\"code\") = {}", params.get("code"));
+        log.info("params.get(\"client_secret\") = {}", params.get("client_secret"));
+
+        log.info("params = {}", params);
 
         return params;
     }


### PR DESCRIPTION
## PR Checklist

- [ ] Commit Convention
- [ ] 변경 사항에 대한 테스트
- [ ] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #107 

## 작업 내용(기대 효과)
### OAuthController
- 인가 코드 및 서버 타입에 대한 로그 추가
- 로그인 후 해당 멤버의 서버 타입에 대한 로그 추가

### OAuthService
- Kakao API 호출 후 멤버의 이메일 로그 추가
- 예외 발생 시 원인과 예외 발생 클래스 로그 추가

### OAuthMemberClientComposite
- Kakao API 호출 후 멤버의 이메일 로그 추가
- 어떤  API Client를 가져오는지에 대한 로그 추가

### KakaoMemberClient
- Request로 받은 인가 코드 로그 추가
- 인가 코드로 엑세스 토큰을 발급 받는 Kakao API 호출 후 엑세스 토큰 및 토큰 정보에 대한 로그 추가
- 발급 받은 엑세스 토큰으로 멤버의 정보 API 요청 후 받은 멤버에 대한 로그 추가
- 인가 토큰으로 엑세스 토큰 발급 받는 Kakao API 요청 시 헤더에 들어가는 파라미터에 대한 로그 추가
## 기타 사항
