### PR TITLE
[#112] Fix: GitHub Repository Name 변경으로 인한 SonarCloud 관련 내용 수정

### DIFF
--- a/.github/workflows/WakuWaku-CI.yml
+++ b/.github/workflows/WakuWaku-CI.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.4'
 
 	id 'jacoco'
-	id "org.sonarqube" version "4.4.1.3373"
+	id "org.sonarqube" version "5.1.0.4882"
 
 	id 'com.epages.restdocs-api-spec' version '0.18.2'
 }
@@ -182,7 +182,7 @@ sonar {
 	properties {
 		// 분석 전에 프로젝트가 컴파일되도록 설정
 		property 'sonar.gradle.skipCompile', 'true'
-		property 'sonar.projectKey', 'AK-47-GrandMother_WakuWaku-Backend'
+		property 'sonar.projectKey', 'WakuWaku-Developer_WakuWaku-BackEnd'
 		property 'sonar.organization', 'wakuwaku'
 		property 'sonar.host.url', 'https://sonarcloud.io'
 		property 'sonar.sources', 'src'


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [x] 빌드 관련
- [x] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명:


## Issue 번호
Issue Number: #112 

## 작업 내용(기대 효과)
GitHub Repository 이름 변경으로 인해 SonarCloud에서 코드 분석을 하지 못하는 이슈가 발생하여 build.gradle의 SonarCloud 관련 내용 및 GitHub Secrets 수정